### PR TITLE
Fix regular expression in prompt

### DIFF
--- a/Ska/Shell.py
+++ b/Ska/Shell.py
@@ -101,7 +101,7 @@ def _setup_tcsh_shell(logfile):
     import pexpect
     prompt = r'Tcsh-%P> '
     prompt2 = r'Tcsh-%P- '
-    re_prompt = re.compile(r'Tcsh-\d\d:\d\d:\d\d([->]) ')
+    re_prompt = re.compile(r'Tcsh-(\d)?\d:\d\d:\d\d([->]) ')
 
     # Tcsh puts an extra \r after the original command, which turns in an extra
     # line that needs to be skipped.


### PR DESCRIPTION
It looks like %P does not always get a two-digit hour, so Ska.Shell was
failing before noon:

> set prompt='Tcsh-%P> '
> Tcsh-7:43:17>

Another option would be to change to prompt to a different format.
