### PR TITLE
Fix tests

### DIFF
--- a/Ska/Shell/__init__.py
+++ b/Ska/Shell/__init__.py
@@ -1,6 +1,6 @@
 from .shell import *
 
-__version__ = '3.3.1'
+__version__ = '3.3.2'
 
 
 def test(*args, **kwargs):

--- a/Ska/Shell/shell.py
+++ b/Ska/Shell/shell.py
@@ -216,7 +216,7 @@ def bash_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None):
     :rtype: (outlines, deltaenv)
     """
     outlines, newenv = run_shell(cmdstr, shell='bash', logfile=logfile,
-                                 importenv=importenv, env=env)
+                                 importenv=importenv, getenv=getenv, env=env)
     return outlines, newenv
 
 
@@ -257,7 +257,7 @@ def tcsh_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None):
     :rtype: (outlines, deltaenv)
     """
     outlines, newenv = run_shell(cmdstr, shell='tcsh', logfile=logfile,
-                                 importenv=importenv, env=env)
+                                 importenv=importenv, getenv=getenv, env=env)
     return outlines, newenv
 
 

--- a/Ska/Shell/tests/test_shell.py
+++ b/Ska/Shell/tests/test_shell.py
@@ -65,22 +65,22 @@ class TestBash:
         assert env == {}
 
     def test_env(self):
-        envs = getenv('export TEST_ENV_VAR="hello"')
-        assert envs['TEST_ENV_VAR'] == 'hello'
-        outlines = bash('echo $TEST_ENV_VAR', env=envs)
+        envs = getenv('export TEST_ENV_VARA="hello"')
+        assert envs['TEST_ENV_VARA'] == 'hello'
+        outlines = bash('echo $TEST_ENV_VARA', env=envs)
         assert outlines == ['hello']
 
     def test_importenv(self):
-        importenv('export TEST_ENV_VAR="hello"', env={'TEST_ENV_VAR2': 'world'})
-        assert os.environ['TEST_ENV_VAR'] == 'hello'
-        assert os.environ['TEST_ENV_VAR2'] == 'world'
+        importenv('export TEST_ENV_VARC="hello"', env={'TEST_ENV_VARB': 'world'})
+        assert os.environ['TEST_ENV_VARC'] == 'hello'
+        assert os.environ['TEST_ENV_VARB'] == 'world'
 
     def test_logfile(self):
         logfile = StringIO()
-        bash('echo line1; echo line2', logfile=logfile)
-        logfile.seek(0)
-        outlines = logfile.read().splitlines()
-        assert outlines[0].startswith('Bash-')
+        cmd = 'echo line1; echo line2'
+        bash(cmd, logfile=logfile)
+        outlines = logfile.getvalue().splitlines()
+        assert outlines[0].endswith(cmd)
         assert outlines[1] == 'line1'
         assert outlines[2] == 'line2'
         assert outlines[3].startswith('Bash')
@@ -115,11 +115,11 @@ class TestTcsh:
 
     def test_logfile(self, tmpdir):
         logfile = StringIO()
-        tcsh('echo line1; echo line2', logfile=logfile)
-        logfile.seek(0)
-        out = logfile.read()
+        cmd = 'echo line1; echo line2'
+        tcsh(cmd, logfile=logfile)
+        out = logfile.getvalue()
         outlines = out.strip().splitlines()
-        assert outlines[0].startswith('Tcsh-')
+        assert outlines[0].endswith(cmd)
         assert outlines[1] == ''
         assert outlines[2] == 'line1'
         assert outlines[3] == 'line2'


### PR DESCRIPTION
This was actually failing in Py3.5 and flight Ska 2.7 in some circumstances.  I think there was an interaction with the python interpreter environment variables from the `importenv` test.

I also found a mistake in the implementation of `bash_shell` and `tcsh_shell`.