### PR TITLE
Ignore shell vars when using a defined env for the shell

### DIFF
--- a/Ska/Shell/__init__.py
+++ b/Ska/Shell/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .shell import *
 
-__version__ = '3.3.2'
+__version__ = '3.3.3'
 
 
 def test(*args, **kwargs):

--- a/Ska/Shell/shell.py
+++ b/Ska/Shell/shell.py
@@ -152,8 +152,16 @@ def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False,
     shell.delaybeforesend = 0.0
 
     if env:
-        setenv_str = "export %s='%s'" if shell_name == 'bash' else "setenv %s '%s'"
+        exclude_vars = []
+        if shell_name == 'bash':
+            setenv_str = "export %s='%s'"
+            exclude_vars = ['PS1', 'PS2', 'PS3', 'PS4', 'PROMPT_COMMAND']
+        else:
+            setenv_str = "setenv %s '%s'"
+            exclude_vars = ['PROMPT', 'PROMPT2']
         for key, val in env.items():
+            if key in exclude_vars:
+                continue
             # Would be better to properly escape any shell characters.
             shell.sendline_expect(setenv_str % (key, val))
 

--- a/Ska/Shell/shell.py
+++ b/Ska/Shell/shell.py
@@ -160,10 +160,9 @@ def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False,
             setenv_str = "setenv %s '%s'"
             exclude_vars = ['PROMPT', 'PROMPT2']
         for key, val in env.items():
-            if key in exclude_vars:
-                continue
-            # Would be better to properly escape any shell characters.
-            shell.sendline_expect(setenv_str % (key, val))
+            if key not in exclude_vars:
+                # Would be better to properly escape any shell characters.
+                shell.sendline_expect(setenv_str % (key, val))
 
     shell.delaybeforesend = 0.01
     outlines = []

--- a/Ska/Shell/tests/test_shell.py
+++ b/Ska/Shell/tests/test_shell.py
@@ -71,6 +71,13 @@ class TestBash:
         outlines = bash('echo $TEST_ENV_VARA', env=envs)
         assert outlines == ['hello']
 
+    def test_promptenv(self):
+        # Confirm that a messed up PS1 won't be a problem
+        # If the user messes with the prompts during use of the shell, all bets are off
+        # This test will just hang if the fix isn't implemented (should add pytest-timeout)
+        outlines = bash("echo 'hello'", env={'PS1': "(hello) \\s-\\v\\$"})
+        assert outlines == ['hello']
+
     def test_importenv(self):
         importenv('export TEST_ENV_VARC="hello"', env={'TEST_ENV_VARB': 'world'})
         assert os.environ['TEST_ENV_VARC'] == 'hello'


### PR DESCRIPTION
Ignore prompt customization shell vars when passing an env to a shell using kwarg env= 