### PR TITLE
Fix bash support on catalina + modernize

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/Ska/Shell/__init__.py
+++ b/Ska/Shell/__init__.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import ska_helpers
+
 from .shell import *
 
-__version__ = '3.3.4'
+__version__ = ska_helpers.get_version(__package__)
 
 
 def test(*args, **kwargs):

--- a/Ska/Shell/shell.py
+++ b/Ska/Shell/shell.py
@@ -7,8 +7,6 @@ import sys
 import signal
 import subprocess
 
-import six
-
 
 class ShellError(Exception):
     pass
@@ -93,7 +91,7 @@ def _setup_bash_shell(logfile):
 
     os.environ['PS1'] = prompt1
     os.environ['PS2'] = prompt2
-    spawn = pexpect.spawn if six.PY2 else pexpect.spawnu
+    spawn = pexpect.spawnu
     shell = spawn('/bin/bash --noprofile --norc --noediting', timeout=1e8)
     shell.logfile_read = logfile
     shell.expect(re_prompt)
@@ -111,7 +109,7 @@ def _setup_tcsh_shell(logfile):
     # line that needs to be skipped.
     pexpect.spawn.sendline_expect = _sendline_expect_func(re_prompt, n_skip=2)
 
-    spawn = pexpect.spawn if six.PY2 else pexpect.spawnu
+    spawn = pexpect.spawnu
     shell = spawn('/bin/tcsh -f', timeout=1e8)
 
     shell.sendline('set prompt="{}"'.format(prompt))

--- a/Ska/Shell/shell.py
+++ b/Ska/Shell/shell.py
@@ -5,6 +5,7 @@ import re
 import os
 import sys
 import signal
+import platform
 import subprocess
 
 
@@ -91,6 +92,8 @@ def _setup_bash_shell(logfile):
 
     os.environ['PS1'] = prompt1
     os.environ['PS2'] = prompt2
+    if platform.system() == 'Darwin':
+        os.environ['BASH_SILENCE_DEPRECATION_WARNING'] = '1'
     spawn = pexpect.spawnu
     shell = spawn('/bin/bash --noprofile --norc --noediting', timeout=1e8)
     shell.logfile_read = logfile

--- a/Ska/Shell/shell.py
+++ b/Ska/Shell/shell.py
@@ -96,7 +96,7 @@ def _setup_bash_shell(logfile):
     spawn = pexpect.spawn if six.PY2 else pexpect.spawnu
     shell = spawn('/bin/bash --noprofile --norc --noediting', timeout=1e8)
     shell.logfile_read = logfile
-    shell.expect(r'.+')
+    shell.expect(re_prompt)
 
     return shell, re_prompt
 

--- a/Ska/Shell/tests/test_shell.py
+++ b/Ska/Shell/tests/test_shell.py
@@ -90,10 +90,15 @@ class TestBash:
         cmd = 'echo line1; echo line2'
         bash(cmd, logfile=logfile)
         outlines = logfile.getvalue().splitlines()
-        assert outlines[0].endswith(cmd)
-        assert outlines[1] == 'line1'
-        assert outlines[2] == 'line2'
-        assert outlines[3].startswith('Bash')
+
+        # Note that starting bash may generate cruft at the beginning (e.g. the
+        # annoying message on catalina that zsh is now the default shell). So
+        # the tests reference expected output from the end of the log not the
+        # beginning.
+        assert outlines[-4].endswith(cmd)
+        assert outlines[-3] == 'line1'
+        assert outlines[-2] == 'line2'
+        assert outlines[-1].startswith('Bash')
 
     @pytest.mark.skipif('not HAS_HEAD_CIAO', reason='Test requires /soft/ciao/bin/ciao.sh')
     def test_ciao(self):

--- a/Ska/Shell/tests/test_shell.py
+++ b/Ska/Shell/tests/test_shell.py
@@ -26,13 +26,13 @@ class TestSpawn:
         spawn = Spawn(stdout=None)
         with pytest.raises(OSError):
             spawn.run('bad command')
-        assert spawn.exitstatus == None
+        assert spawn.exitstatus is None
 
     def test_timeout_error(self):
         spawn = Spawn(shell=True, timeout=1, stdout=None)
         with pytest.raises(RunTimeoutError):
             spawn.run('sleep 5')
-        assert spawn.exitstatus == None
+        assert spawn.exitstatus is None
 
     def test_grab_stderr(self, tmpdir):
         tmp = tmpdir.join("test.out")
@@ -152,7 +152,3 @@ class TestTcsh:
         test_script = ['printenv {}'.format(name) for name in sorted(envs)]
         outlines = tcsh('\n'.join(test_script), env=envs)
         assert outlines == [envs[name] for name in sorted(envs)]
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from setuptools import setup
 
-from Ska.Shell import __version__
 try:
     from testr.setup_helper import cmdclass
 except ImportError:
@@ -11,7 +10,8 @@ setup(name='Ska.Shell',
       author='Tom Aldcroft',
       description='Various shell utilities',
       author_email='taldcroft@cfa.harvard.edu',
-      version=__version__,
+      use_scm_version=True,
+      setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
       zip_safe=False,
       packages=['Ska', 'Ska.Shell', 'Ska.Shell.tests'],
       tests_require=['pytest'],


### PR DESCRIPTION
When starting bash on MacOSX catalina one now gets a message that zsh is now the default interpreter shell.  This breaks Ska.Shell completely, which I first noticed trying to run `ska_testr`.  

This PR fixes this, but to be honest I don't 100% understand why Ska.Shell was ever working at all.  The first thing it does (in master) when starting a shell is do an `spawn.expect('.+')`.  As noted [in the documentation](https://pexpect.readthedocs.io/en/stable/overview.html#beware-of-and-at-the-end-of-patterns) that is a useless anti-pattern.  It could be that the `n_skip=1` default was letting this work somewhat accidentally.

https://github.com/sot/Ska.Shell/blob/6c345e29d4c3632bcf8d31b0acc3b183abf61187/Ska/Shell/shell.py#L99

This also does minor modernizing by dropping support for Python 2.7 and fixing some flake8 issues.

## Testing

Passes unit tests on:
- [x] CentOS-7 (kady)
- [x] CentOS-5 (presto)
- [x] MacOSX catalina
- [x] MaxOSX mojave
