### PR TITLE
Skip all tests on Windows

### DIFF
--- a/Ska/Shell/tests/test_shell.py
+++ b/Ska/Shell/tests/test_shell.py
@@ -9,6 +9,9 @@ HAS_HEAD_CIAO = os.path.exists('/soft/ciao/bin/ciao.sh')
 
 outfile = 'ska_shell_test.dat'
 
+# Skip the entire test suite on Windows
+pytestmark = pytest.mark.skipif(os.name == 'nt', reason='Ska.Shell not supported on Windows')
+
 
 class TestSpawn:
     def setup(self):


### PR DESCRIPTION
## Description

Ska.Shell is completely incompatible with Windows since it relies on ALARM signals throughout.  So just skip all the tests so automated integration testing passes.

## Testing

- [x] Passes unit tests on MacOS and Windows
