### PR TITLE
Use explicit package name in call to get_version

### DIFF
--- a/Ska/Shell/__init__.py
+++ b/Ska/Shell/__init__.py
@@ -3,7 +3,7 @@ import ska_helpers
 
 from .shell import *
 
-__version__ = ska_helpers.get_version(__package__)
+__version__ = ska_helpers.get_version('Ska.Shell')
 
 
 def test(*args, **kwargs):


### PR DESCRIPTION
## Description

Use explicit package name to avoid problems with pytest and ska_helpers.version.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

Ran `python -c 'import Ska.Shell; Ska.Shell.test()` and saw no pytest warnings.

Without the patch:
```
============================================ test session starts ============================================
platform darwin -- Python 3.7.7, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
rootdir: /Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.7/site-packages
collected 20 items                                                                                          

Ska/Shell/tests/test_shell.py ............s.......                                                    [100%]

============================================= warnings summary ==============================================
/Users/aldcroft/git/ska_helpers/ska_helpers/version.py:87
  /Users/aldcroft/git/ska_helpers/ska_helpers/version.py:87: UserWarning: Traceback (most recent call last):
    File "/Users/aldcroft/git/ska_helpers/ska_helpers/version.py", line 39, in get_version
      dist_info = get_distribution(distribution or package)
    File "/Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.7/site-packages/pkg_resources/__init__.py", line 481, in get_distribution
      dist = get_provider(dist)
    File "/Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.7/site-packages/pkg_resources/__init__.py", line 357, in get_provider
      return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
    File "/Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.7/site-packages/pkg_resources/__init__.py", line 900, in require
      needed = self.resolve(parse_requirements(requirements))
    File "/Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.7/site-packages/pkg_resources/__init__.py", line 786, in resolve
      raise DistributionNotFound(req, requirers)
  pkg_resources.DistributionNotFound: The 'Shell' distribution was not found and is required by the application
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/Users/aldcroft/git/ska_helpers/ska_helpers/version.py", line 76, in get_version
      version = get_version(root=Path(*roots), relative_to=module_file)
    File "/Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.7/site-packages/setuptools_scm/__init__.py", line 144, in get_version
      return _get_version(config)
    File "/Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.7/site-packages/setuptools_scm/__init__.py", line 148, in _get_version
      parsed_version = _do_parse(config)
    File "/Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.7/site-packages/setuptools_scm/__init__.py", line 118, in _do_parse
      "use git+https://github.com/user/proj.git#egg=proj" % config.absolute_root
  LookupError: setuptools-scm was unable to detect version for '/Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.7/site-packages/Ska'.
  
  Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.
  
  For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj
  
  
  
    warnings.warn(traceback.format_exc() + '\n\n')

/Users/aldcroft/git/ska_helpers/ska_helpers/version.py:88
  /Users/aldcroft/git/ska_helpers/ska_helpers/version.py:88: UserWarning: Failed to find a package version, setting to 0.0.0
    warnings.warn('Failed to find a package version, setting to 0.0.0')

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=========================== 19 passed, 1 skipped, 2 warnings in 600.63s (0:10:00) ===========================
```