### PR TITLE
Fix for RedHat 8 (env vars that are functions)

### DIFF
--- a/Ska/Shell/shell.py
+++ b/Ska/Shell/shell.py
@@ -73,7 +73,7 @@ def _parse_keyvals(keyvals):
     re_keyval = re.compile(r'([\w_]+) \s* = \s* (.*)', re.VERBOSE)
     keyvalout = {}
     for keyval in keyvals:
-        m = re.search(re_keyval, keyval.strip())
+        m = re.match(re_keyval, keyval.rstrip())
         if m:
             key, val = m.groups()
             keyvalout[key] = val


### PR DESCRIPTION
## Description

This is a fix for #25. In the end it is easy.

The source of the problem is that there are multi-line environmental variables (functions, actually), and the "parsing" of the environment wrongly matches lines within these multi-line variables as if they were variable definitions.

`printenv` indents the contents of these functions (the inner-scope lines start with a space). A normal variable definition does not start with space. Therefore, the solution is to ignore lines starting with space.

That is: replace `re.search(..., s.strip())` by `re.match(..., s.rstrip())`

Fixes #25

## Interface impacts
None

## Testing

When doing tests, verified that tests pass in this PR and fail in master.

### Unit tests
- [x] Linux (rh8)

Independent check of unit tests by @taldcroft 
- [x] Mac
- [x] Linux (CentOS-7, kady) 

### Functional tests
tried the specific test in #25:
```
from Ska.Shell import getenv, bash, run_shell
envs = getenv('export TEST_ENV_VARA="hello"')
bash('echo $TEST_ENV_VARA', env=envs)
```

@taldcroft  also confirmed this functional test on han8-v (RH8) and kady (CentOS-7)