### PR TITLE
WIP: No pexpect

### DIFF
--- a/ska_shell/tests/test_shell.py
+++ b/ska_shell/tests/test_shell.py
@@ -74,8 +74,22 @@ class TestBash:
     def test_env(self):
         envs = getenv('export TEST_ENV_VARA="hello"')
         assert envs['TEST_ENV_VARA'] == 'hello'
+        assert "TEST_ENV_VARA" not in os.environ
+
         outlines = bash('echo $TEST_ENV_VARA', env=envs)
         assert outlines == ['hello']
+
+        envs = getenv("echo", env={"TEST_ENV_VARA": "one"}, shell='bash')
+        assert envs['TEST_ENV_VARA'] == 'one'
+        assert "TEST_ENV_VARA" not in os.environ
+
+        envs = getenv("echo", env={"TEST_ENV_VARA": "two"}, shell='bash', importenv=True)
+        assert envs['TEST_ENV_VARA'] == 'two'
+        assert os.environ["TEST_ENV_VARA"] == 'two'
+
+        envs = getenv('export TEST_ENV_VARA="hello"', shell='bash', importenv=True)
+        assert envs['TEST_ENV_VARA'] == 'hello'
+        assert os.environ["TEST_ENV_VARA"] == 'hello'
 
     def test_promptenv(self):
         # Confirm that a messed up PS1 won't be a problem
@@ -125,8 +139,22 @@ class TestTcsh:
     def test_env(self):
         envs = getenv('setenv TEST_ENV_VAR2 "hello"', shell='tcsh')
         assert envs['TEST_ENV_VAR2'] == 'hello'
+        assert "TEST_ENV_VAR2" not in os.environ
+
         outlines = tcsh('echo $TEST_ENV_VAR2', env=envs)
         assert outlines == ['hello']
+
+        envs = getenv("echo", env={"TEST_ENV_VAR2": "one"}, shell='tcsh')
+        assert envs['TEST_ENV_VAR2'] == 'one'
+        assert "TEST_ENV_VAR2" not in os.environ
+
+        envs = getenv("echo", env={"TEST_ENV_VAR2": "two"}, shell='tcsh', importenv=True)
+        assert envs['TEST_ENV_VAR2'] == 'two'
+        assert os.environ["TEST_ENV_VAR2"] == 'two'
+
+        envs = getenv('setenv TEST_ENV_VAR2 "hello"', shell='tcsh', importenv=True)
+        assert envs['TEST_ENV_VAR2'] == 'hello'
+        assert os.environ["TEST_ENV_VAR2"] == 'hello'
 
     def test_importenv(self):
         importenv('setenv TEST_ENV_VAR3 "hello"', env={'TEST_ENV_VAR4': 'world'}, shell='tcsh')

--- a/ska_shell/tests/test_shell.py
+++ b/ska_shell/tests/test_shell.py
@@ -6,6 +6,7 @@ from ska_shell import (Spawn, RunTimeoutError, bash, tcsh, getenv, importenv,
                        tcsh_shell, bash_shell)
 
 HAS_HEAD_CIAO = os.path.exists('/soft/ciao/bin/ciao.sh')
+HAS_HEAD_ASCDS = os.path.exists('/home/ascds/.ascrc')
 
 outfile = 'ska_shell_test.dat'
 
@@ -144,12 +145,14 @@ class TestTcsh:
         assert outlines[3] == 'line2'
         assert outlines[4].startswith('Tcsh')
 
+    @pytest.mark.skipif('not HAS_HEAD_ASCDS', reason='Test requires /home/ascds/.ascrc')
     def test_ascds(self):
         envs = getenv('source /home/ascds/.ascrc -r release', shell='tcsh')
         test_script = ['printenv {}'.format(name) for name in sorted(envs)]
         outlines = tcsh('\n'.join(test_script), env=envs)
         assert outlines == [envs[name] for name in sorted(envs)]
 
+    @pytest.mark.skipif('not HAS_HEAD_CIAO', reason='Test requires /soft/ciao/bin/ciao.sh')
     def test_ciao(self):
         envs = getenv('source /soft/ciao/bin/ciao.csh', shell='tcsh')
         test_script = ['printenv {}'.format(name) for name in sorted(envs)]


### PR DESCRIPTION
## Description

This PR changes the `getenv` function so it does not use pexpect.

It is possible to replace all functionality so it doesn't use pexpect, but I'm not sure we want to. The reason is that in most cases the calling code can just replace the calls to ska_shell with a line calling subprocess, and that is less work than making ska_shell pexpect-free. In case where we care about a specific behavior, I don't see the point of forcing the current ska_shell interface and behavior. For example:
- ska_shell has a `logfile` argument, but in this day and age we would prefer a `logging.Logger` or just a function.
- ska_shell updates the output in real-time, which can be convenient. I did that in runasp using subprocess, but in most cases we do not need that.
- ska_shell has an `importenv` argument to `run_shell`, but it can do that because it can make one last call to the shell instance to get the environment. In subprocess, it would require a bit of work.

If one does not care about keeping the exact arguments and behavior, then it is trivial to replace pexpect with subprocess.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
