### PR TITLE
No pexpect

### DIFF
--- a/ska_shell/__init__.py
+++ b/ska_shell/__init__.py
@@ -3,12 +3,13 @@ import ska_helpers
 
 from .shell import *
 
-__version__ = ska_helpers.get_version('ska_shell')
+__version__ = ska_helpers.get_version("ska_shell")
 
 
 def test(*args, **kwargs):
-    '''
+    """
     Run py.test unit tests.
-    '''
+    """
     import testr
+
     return testr.test(*args, **kwargs)

--- a/ska_shell/shell.py
+++ b/ska_shell/shell.py
@@ -175,9 +175,8 @@ def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False,
 def bash_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None, logger=None, log_level=None):
     """
     Run the command string ``cmdstr`` in a bash shell.  It can have
-    multiple lines.  Each line is separately sent to the shell.  The exit status is
-    checked if the shell comes back with a prompt. If exit status is non-zero at any point
-    then processing is terminated and a ``ShellError`` exception is raise.
+    multiple lines. If exit status is non-zero at any point
+    then processing is terminated and a ``ShellError`` exception is raised.
 
     :param cmdstr: command string
     :param shell: shell for command -- 'bash' (default) or 'tcsh'
@@ -222,9 +221,8 @@ def tcsh(cmdstr, logfile=None, importenv=False, env=None, logger=None, log_level
 def tcsh_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None, logger=None, log_level=None):
     """
     Run the command string ``cmdstr`` in a tcsh shell.  It can have
-    multiple lines.  Each line is separately sent to the shell.  The exit status is
-    checked if the shell comes back with a prompt. If exit status is non-zero at any point
-    then processing is terminated and a ``ShellError`` exception is raise.
+    multiple lines. If exit status is non-zero at any point
+    then processing is terminated and a ``ShellError`` exception is raised.
 
     :param cmdstr: command string
     :param shell: shell for command -- 'bash' (default) or 'tcsh'

--- a/ska_shell/shell.py
+++ b/ska_shell/shell.py
@@ -159,15 +159,17 @@ def run_shell(
     cmdstr = " && ".join([c for c in cmdstr.splitlines() if c.strip()])
 
     # make sure the RC file is not sourced in csh (option -f) and abort on error (option -e)
+    actual_shell = shell
+    actual_cmdstr = cmdstr
     if shell in ["tcsh", "csh"]:
-        cmdstr = f"{shell} {'-e' if check else ''} -f -c '{cmdstr}'"
-        shell = "bash"
+        actual_cmdstr = f"{shell} {'-e' if check else ''} -f -c '{actual_cmdstr}'"
+        actual_shell = "bash"
     elif shell in ["bash", "zsh"] and check:
-        cmdstr = f"set -e; {cmdstr}"
+        actual_cmdstr = f"set -e; {actual_cmdstr}"
 
     proc = subprocess.Popen(
-        [cmdstr],
-        executable=shell,
+        [actual_cmdstr],
+        executable=actual_shell,
         shell=True,
         env=environ,
         stdout=subprocess.PIPE,
@@ -195,7 +197,7 @@ def run_shell(
     deltaenv = dict()
     if importenv or getenv:
         expected_diff_set = (
-            set(("PS1", "PS2", "_", "SHLVL")) if shell in ["bash", "zsh"] else set()
+            set(("PS1", "PS2", "_", "SHLVL")) if actual_shell in ["bash", "zsh"] else set()
         )
         currenv = dict(os.environ)
         _fix_paths(newenv)

--- a/ska_shell/shell.py
+++ b/ska_shell/shell.py
@@ -128,6 +128,9 @@ def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False,
     if importenv or getenv:
         cmdstr += " && echo __PRINTENV__ && printenv"
 
+    # all lines are joined so the shell exits at the first failure
+    cmdstr = " && ".join([c for c in cmdstr.splitlines() if c.strip()])
+
     proc = subprocess.Popen(
         [cmdstr],
         executable=shell,

--- a/ska_shell/shell.py
+++ b/ska_shell/shell.py
@@ -15,6 +15,10 @@ class ShellError(Exception):
     pass
 
 
+class NonZeroReturnCode(ShellError):
+    pass
+
+
 def _fix_paths(envs, pathvars=('PATH', 'PERLLIB', 'PERL5LIB', 'PYTHONPATH',
                                'LD_LIBRARY_PATH', 'MANPATH', 'INFOPATH')):
     """For the specified env vars that represent a search path, make sure that the
@@ -148,7 +152,7 @@ def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False,
         logfile.write(f"{shell.capitalize()}-{time}>\n")
     if proc.returncode:
         msg = " ".join(stdout[-1:])  # stdout could be empty
-        exc = ShellError(f"Shell error: {msg}")
+        exc = NonZeroReturnCode(f"Shell error: {msg}")
         exc.lines = stdout
         raise exc
 

--- a/ska_shell/shell.py
+++ b/ska_shell/shell.py
@@ -135,6 +135,7 @@ def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False,
     # all lines are joined so the shell exits at the first failure
     cmdstr = " && ".join([c for c in cmdstr.splitlines() if c.strip()])
 
+    # make sure the RC file is not sourced
     if shell in ["tcsh", "csh"]:
         cmdstr = f"{shell} -f -c '{cmdstr}'"
         shell = "bash"

--- a/ska_shell/shell.py
+++ b/ska_shell/shell.py
@@ -19,8 +19,18 @@ class NonZeroReturnCode(ShellError):
     pass
 
 
-def _fix_paths(envs, pathvars=('PATH', 'PERLLIB', 'PERL5LIB', 'PYTHONPATH',
-                               'LD_LIBRARY_PATH', 'MANPATH', 'INFOPATH')):
+def _fix_paths(
+    envs,
+    pathvars=(
+        "PATH",
+        "PERLLIB",
+        "PERL5LIB",
+        "PYTHONPATH",
+        "LD_LIBRARY_PATH",
+        "MANPATH",
+        "INFOPATH",
+    ),
+):
     """For the specified env vars that represent a search path, make sure that the
     paths are unique.  This allows the environment setting script to be lazy
     and not worry about it.  This routine gives the right-most path precedence
@@ -33,7 +43,7 @@ def _fix_paths(envs, pathvars=('PATH', 'PERLLIB', 'PERL5LIB', 'PYTHONPATH',
 
     # Process env vars that are contained in the PATH_ENVS set
     for key in set(envs.keys()) & set(pathvars):
-        path_ins = envs[key].split(':')
+        path_ins = envs[key].split(":")
         pathset = set()
         path_outs = []
         # Working from right to left add each path that hasn't been included yet.
@@ -41,7 +51,7 @@ def _fix_paths(envs, pathvars=('PATH', 'PERLLIB', 'PERL5LIB', 'PYTHONPATH',
             if path not in pathset:
                 pathset.add(path)
                 path_outs.append(path)
-        envs[key] = ':'.join(reversed(path_outs))
+        envs[key] = ":".join(reversed(path_outs))
 
 
 def _parse_keyvals(keyvals):
@@ -50,7 +60,7 @@ def _parse_keyvals(keyvals):
     :param keyvals: Newline-separated string with key=val pairs
     :rtype: Dict of key=val pairs.
     """
-    re_keyval = re.compile(r'([\w_]+) \s* = \s* (.*)', re.VERBOSE)
+    re_keyval = re.compile(r"([\w_]+) \s* = \s* (.*)", re.VERBOSE)
     keyvalout = {}
     for keyval in keyvals:
         m = re.match(re_keyval, keyval)
@@ -106,7 +116,16 @@ def _shell_ok(shell):
     return p.returncode == 0
 
 
-def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False, env=None, logger=None, log_level=None):
+def run_shell(
+    cmdstr,
+    shell="bash",
+    logfile=None,
+    importenv=False,
+    getenv=False,
+    env=None,
+    logger=None,
+    log_level=None,
+):
     """
     Run the command string ``cmdstr`` in a ``shell`` ('bash' or 'tcsh').  It can have
     multiple lines.  Each line is separately sent to the shell.  The exit status is
@@ -163,13 +182,15 @@ def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False,
 
     newenv = {}
     if "__PRINTENV__" in stdout:
-        newenv = _parse_keyvals(stdout[stdout.index("__PRINTENV__") + 1:])
-        stdout = stdout[:stdout.index("__PRINTENV__")]
+        newenv = _parse_keyvals(stdout[stdout.index("__PRINTENV__") + 1 :])
+        stdout = stdout[: stdout.index("__PRINTENV__")]
 
     # Update os.environ based on changes to environment made by cmdstr
     deltaenv = dict()
     if importenv or getenv:
-        expected_diff_set = set(('PS1', 'PS2', '_', 'SHLVL')) if shell in ['bash', "zsh"] else set()
+        expected_diff_set = (
+            set(("PS1", "PS2", "_", "SHLVL")) if shell in ["bash", "zsh"] else set()
+        )
         currenv = dict(os.environ)
         _fix_paths(newenv)
         for key in set(newenv) - expected_diff_set:
@@ -181,7 +202,15 @@ def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False,
     return stdout, deltaenv
 
 
-def bash_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None, logger=None, log_level=None):
+def bash_shell(
+    cmdstr,
+    logfile=None,
+    importenv=False,
+    getenv=False,
+    env=None,
+    logger=None,
+    log_level=None,
+):
     """
     Run the command string ``cmdstr`` in a bash shell.  It can have
     multiple lines. If exit status is non-zero at any point
@@ -200,13 +229,13 @@ def bash_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None, lo
     """
     outlines, newenv = run_shell(
         cmdstr,
-        shell='bash',
+        shell="bash",
         logfile=logfile,
         importenv=importenv,
         getenv=getenv,
-         env=env,
+        env=env,
         logger=logger,
-        log_level=log_level
+        log_level=log_level,
     )
     return outlines, newenv
 
@@ -216,7 +245,15 @@ def bash(cmdstr, logfile=None, importenv=False, env=None, logger=None, log_level
 
     :returns: bash output
     """
-    return run_shell(cmdstr, shell='bash', logfile=logfile, importenv=importenv, env=env, logger=logger, log_level=log_level)[0]
+    return run_shell(
+        cmdstr,
+        shell="bash",
+        logfile=logfile,
+        importenv=importenv,
+        env=env,
+        logger=logger,
+        log_level=log_level,
+    )[0]
 
 
 def tcsh(cmdstr, logfile=None, importenv=False, env=None, logger=None, log_level=None):
@@ -224,10 +261,26 @@ def tcsh(cmdstr, logfile=None, importenv=False, env=None, logger=None, log_level
 
     :returns: tcsh output
     """
-    return run_shell(cmdstr, shell='tcsh', logfile=logfile, importenv=importenv, env=env, logger=logger, log_level=log_level)[0]
+    return run_shell(
+        cmdstr,
+        shell="tcsh",
+        logfile=logfile,
+        importenv=importenv,
+        env=env,
+        logger=logger,
+        log_level=log_level,
+    )[0]
 
 
-def tcsh_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None, logger=None, log_level=None):
+def tcsh_shell(
+    cmdstr,
+    logfile=None,
+    importenv=False,
+    getenv=False,
+    env=None,
+    logger=None,
+    log_level=None,
+):
     """
     Run the command string ``cmdstr`` in a tcsh shell.  It can have
     multiple lines. If exit status is non-zero at any point
@@ -246,28 +299,30 @@ def tcsh_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None, lo
     """
     outlines, newenv = run_shell(
         cmdstr,
-        shell='tcsh',
+        shell="tcsh",
         logfile=logfile,
         importenv=importenv,
         getenv=getenv,
-         env=env,
+        env=env,
         logger=logger,
-        log_level=log_level
+        log_level=log_level,
     )
     return outlines, newenv
 
 
-def getenv(cmdstr, shell='bash', importenv=False, env=None):
+def getenv(cmdstr, shell="bash", importenv=False, env=None):
     """Run the ``cmdstr`` string in ``shell``.  See ``run_shell`` for options.
 
     :returns: Dict of environment vars update produced by ``cmdstr``
     """
 
-    _, newenv = run_shell(cmdstr, shell=shell, importenv=importenv, env=env, getenv=True)
+    _, newenv = run_shell(
+        cmdstr, shell=shell, importenv=importenv, env=env, getenv=True
+    )
     return newenv
 
 
-def importenv(cmdstr, shell='bash', env=None):
+def importenv(cmdstr, shell="bash", env=None):
     """Run ``cmdstr`` in a bash shell and import the environment updates into the
     current python environment (os.environ).  See ``bash_shell`` for options.
 
@@ -344,27 +399,39 @@ class Spawn(object):
      - openfiles: List of file objects created during init corresponding
                   to filenames supplied in ``outputs`` list
     """
+
     def _open_for_write(self, f):
         """Return a file object for writing for ``f``, which may be nothing, a file
         name, or a file-like object."""
         if not f:
             return _NullFile()
         # Else see if it is a single file-like object
-        elif hasattr(f, 'write') and hasattr(f, 'close'):
+        elif hasattr(f, "write") and hasattr(f, "close"):
             return f
         else:
-            openfile = open(f, 'w', 1)  # raises TypeError if f is not suitable
-            self.openfiles.append(openfile)  # Store open file objects created by this object
+            openfile = open(f, "w", 1)  # raises TypeError if f is not suitable
+            self.openfiles.append(
+                openfile
+            )  # Store open file objects created by this object
             return openfile
 
     @staticmethod
     def _timeout_handler(pid, timeout):
         def handler(signum, frame):
-            raise RunTimeoutError('Process pid=%d timed out after %d secs' % (pid, timeout))
+            raise RunTimeoutError(
+                "Process pid=%d timed out after %d secs" % (pid, timeout)
+            )
+
         return handler
 
-    def __init__(self, stdout=sys.stdout, timeout=None, catch=False,
-                 stderr=subprocess.STDOUT, shell=False):
+    def __init__(
+        self,
+        stdout=sys.stdout,
+        timeout=None,
+        catch=False,
+        stderr=subprocess.STDOUT,
+        shell=False,
+    ):
         """Create a Spawn object to run shell processes in a controlled way.
 
         :param stdout: destination(s) for process stdout.  Can be None, a file name,
@@ -382,7 +449,7 @@ class Spawn(object):
         self.catch = catch
         self.stderr = stderr
         self.shell = shell
-        self.openfiles = []             # Newly opened file objects for stdout
+        self.openfiles = []  # Newly opened file objects for stdout
 
         # stdout can be None, <file>, 'filename', or sequence(..) of these
         try:
@@ -425,11 +492,17 @@ class Spawn(object):
         self.exitstatus = None
 
         try:
-            self.process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=stderr, shell=shell,
-                                            universal_newlines=True)
+            self.process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=stderr,
+                shell=shell,
+                universal_newlines=True,
+            )
 
-            prev_alarm_handler = signal.signal(signal.SIGALRM,
-                                               Spawn._timeout_handler(self.process.pid, timeout))
+            prev_alarm_handler = signal.signal(
+                signal.SIGALRM, Spawn._timeout_handler(self.process.pid, timeout)
+            )
             signal.alarm(self.timeout)
             for line in self.process.stdout:
                 self._write(line)
@@ -440,13 +513,13 @@ class Spawn(object):
 
         except RunTimeoutError as e:
             if catch:
-                self._write('Warning - RunTimeoutError: %s\n' % e)
+                self._write("Warning - RunTimeoutError: %s\n" % e)
             else:
                 raise
 
         except OSError as e:
             if catch:
-                self._write('Warning - OSError: %s\n' % e)
+                self._write("Warning - OSError: %s\n" % e)
             else:
                 raise
 

--- a/ska_shell/shell.py
+++ b/ska_shell/shell.py
@@ -135,6 +135,10 @@ def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False,
     # all lines are joined so the shell exits at the first failure
     cmdstr = " && ".join([c for c in cmdstr.splitlines() if c.strip()])
 
+    if shell in ["tcsh", "csh"]:
+        shell = "bash"
+        cmdstr = f"{shell} -f -c '{cmdstr}'"
+
     proc = subprocess.Popen(
         [cmdstr],
         executable=shell,

--- a/ska_shell/shell.py
+++ b/ska_shell/shell.py
@@ -136,8 +136,8 @@ def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False,
     cmdstr = " && ".join([c for c in cmdstr.splitlines() if c.strip()])
 
     if shell in ["tcsh", "csh"]:
-        shell = "bash"
         cmdstr = f"{shell} -f -c '{cmdstr}'"
+        shell = "bash"
 
     proc = subprocess.Popen(
         [cmdstr],

--- a/ska_shell/shell.py
+++ b/ska_shell/shell.py
@@ -16,7 +16,9 @@ class ShellError(Exception):
 
 
 class NonZeroReturnCode(ShellError):
-    pass
+    def __init__(self, msg, return_code):
+        super().__init__(msg)
+        self.return_code = return_code
 
 
 def _fix_paths(
@@ -184,7 +186,11 @@ def run_shell(
         logfile.write(f"{shell.capitalize()}-{time}>\n")
     if check and proc.returncode:
         msg = " ".join(stdout[-1:])  # stdout could be empty
-        exc = NonZeroReturnCode(f"Shell error: {msg}")
+        exc = NonZeroReturnCode(
+            f"Shell command failed with return_code={proc.returncode}: {msg}."
+            f"Command: {cmdstr}",
+            return_code=proc.returncode
+        )
         exc.lines = stdout
         raise exc
 

--- a/ska_shell/shell.py
+++ b/ska_shell/shell.py
@@ -1,42 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utilities to run subprocesses"""
 
+import datetime
+import functools
+import logging
 import re
 import os
 import sys
 import signal
-import platform
 import subprocess
 
 
 class ShellError(Exception):
     pass
-
-# Give pexpect.spawn a new convenience method that sends a line and expects the prompt
-
-
-def _sendline_expect_func(prompt, n_skip=1):
-    """Returns a convenience method to monkey-patch into pexpect.spawn."""
-    def sendline_expect(self, cmd, quiet=False):
-        """Send a command and expect the given prompt.  Return the 'before' part"""
-        if quiet:
-            logfile_read = self.logfile_read
-            self.logfile_read = None
-
-        self.sendline(cmd)
-        self.expect(prompt)
-
-        if prompt.search(cmd):
-            self.expect(prompt)
-        if quiet:
-            self.logfile_read = logfile_read
-
-        return self.before.splitlines()[n_skip:]
-
-    return sendline_expect
-
-# See skare/install.py for the Template code that can do interpolation of all
-# shell ${var} variables for debug
 
 
 def _fix_paths(envs, pathvars=('PATH', 'PERLLIB', 'PERL5LIB', 'PYTHONPATH',
@@ -73,59 +49,60 @@ def _parse_keyvals(keyvals):
     re_keyval = re.compile(r'([\w_]+) \s* = \s* (.*)', re.VERBOSE)
     keyvalout = {}
     for keyval in keyvals:
-        m = re.match(re_keyval, keyval.rstrip())
+        m = re.match(re_keyval, keyval)
         if m:
             key, val = m.groups()
             keyvalout[key] = val
     return keyvalout
 
 
-def _setup_bash_shell(logfile):
-    # Import pexpect here so that this the other (Spawn) part of this module
-    # doesn't depend on pexpect (which is not in the std library)
-    import pexpect
-    prompt1 = r'Bash-\t> '
-    prompt2 = r'Bash-\t- '
-    re_prompt = re.compile(r'Bash-\d\d:\d\d:\d\d([->]) ')
+def communicate(process, logfile=None, logger=None, log_level=None):
+    """
+    Real-time reading of a subprocess stdout.
 
-    pexpect.spawn.sendline_expect = _sendline_expect_func(re_prompt, n_skip=1)
+    Parameters
+    ----------
+    :param process: process returned by subprocess.Popen
+    :param logfile: append output to the suppplied file object
+    :param logger: log output to the supplied logging.Logger
+    :param log_level: log level for logger
+    """
+    log_level = "INFO" if log_level is None else log_level
+    log_level = getattr(logging, log_level) if type(log_level) is str else log_level
 
-    os.environ['PS1'] = prompt1
-    os.environ['PS2'] = prompt2
-    if platform.system() == 'Darwin':
-        os.environ['BASH_SILENCE_DEPRECATION_WARNING'] = '1'
-    spawn = pexpect.spawnu
-    shell = spawn('/bin/bash --noprofile --norc --noediting', timeout=1e8)
-    shell.logfile_read = logfile
-    shell.expect(re_prompt)
+    lines = []
+    while True:
+        if process.poll() is not None:
+            break
+        line = process.stdout.readline()
+        line = line.decode() if isinstance(line, bytes) else line
+        if line:
+            if logfile:
+                logfile.write(line)
+            if logger is not None:
+                logger.log(log_level, line[:-1])
+            lines.append(line[:-1])
 
-    return shell, re_prompt
+    # in case the buffer is still not empty after the process ended
+    for line in process.stdout.readlines():
+        line = line.decode() if isinstance(line, bytes) else line
+        if line:
+            if logfile:
+                logfile.write(line)
+            if logger is not None:
+                logger.log(log_level, line[:-1])
+            lines.append(line[:-1])
 
-
-def _setup_tcsh_shell(logfile):
-    import pexpect
-    prompt = r'Tcsh-%P> '
-    prompt2 = r'Tcsh-%P- '
-    re_prompt = re.compile(r'Tcsh-(\d)?\d:\d\d:\d\d([->]) ')
-
-    # Tcsh puts an extra \r after the original command, which turns in an extra
-    # line that needs to be skipped.
-    pexpect.spawn.sendline_expect = _sendline_expect_func(re_prompt, n_skip=2)
-
-    spawn = pexpect.spawnu
-    shell = spawn('/bin/tcsh -f', timeout=1e8)
-
-    shell.sendline('set prompt="{}"'.format(prompt))
-    shell.expect(re_prompt)
-    shell.sendline('set prompt2="{}"'.format(prompt2))
-    shell.expect(prompt2)
-    shell.logfile_read = logfile
-    shell.expect(re_prompt)
-
-    return shell, re_prompt
+    return lines
 
 
-def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False, env=None):
+@functools.cache
+def _shell_ok(shell):
+    p = subprocess.run(["which", shell], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return p.returncode == 0
+
+
+def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False, env=None, logger=None, log_level=None):
     """
     Run the command string ``cmdstr`` in a ``shell`` ('bash' or 'tcsh').  It can have
     multiple lines.  Each line is separately sent to the shell.  The exit status is
@@ -141,55 +118,47 @@ def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False,
 
     :rtype: (outlines, deltaenv)
     """
-    shell_name = shell
-    if shell_name == 'bash':
-        setup_shell_func = _setup_bash_shell
-    elif shell_name == 'tcsh':
-        setup_shell_func = _setup_tcsh_shell
-    else:
-        raise ValueError("shell argument must be 'bash' or 'tcsh'")
+    environ = dict(os.environ)
+    if env is not None:
+        environ.update(env)
 
-    shell, re_prompt = setup_shell_func(logfile)
-    shell.delaybeforesend = 0.0
+    if not _shell_ok(shell):
+        raise Exception(f'Failed to find "{shell}" shell')
 
-    if env:
-        exclude_vars = []
-        if shell_name == 'bash':
-            setenv_str = "export %s='%s'"
-            exclude_vars = ['PS1', 'PS2', 'PS3', 'PS4', 'PROMPT_COMMAND']
-        else:
-            setenv_str = "setenv %s '%s'"
-            exclude_vars = ['PROMPT', 'PROMPT2']
-        for key, val in env.items():
-            if key not in exclude_vars:
-                # Would be better to properly escape any shell characters.
-                shell.sendline_expect(setenv_str % (key, val))
+    if importenv or getenv:
+        cmdstr += " && echo __PRINTENV__ && printenv"
 
-    shell.delaybeforesend = 0.01
-    outlines = []
-    for line in cmdstr.splitlines():
-        outlines += shell.sendline_expect(line)
+    proc = subprocess.Popen(
+        [cmdstr],
+        executable=shell,
+        shell=True,
+        env=environ,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if logfile:
+        time = datetime.datetime.now().isoformat()[:22]
+        logfile.write(f"{shell.capitalize()}-{time}> {cmdstr}\n")
+    stdout = communicate(proc, logfile=logfile, logger=logger, log_level=log_level)
+    if logfile:
+        time = datetime.datetime.now().isoformat()[:22]
+        logfile.write(f"{shell.capitalize()}-{time}>\n")
+    if proc.returncode:
+        msg = " ".join(stdout[-1:])  # stdout could be empty
+        exc = ShellError(f"Shell error: {msg}")
+        exc.lines = stdout
+        raise exc
 
-        if re_prompt.match(shell.after).group(1) == '>':
-            try:
-                status_lines = shell.sendline_expect('echo $?', quiet=True)
-                exitstr = status_lines[0].strip()
-                exitstatus = int(exitstr)
-            except ValueError:
-                msg = ("Shell / expect got out of sync:\n" +
-                       "Response to 'echo $?' was apparently '%s'" % exitstr)
-                raise ShellError(msg)
-
-            if exitstatus > 0:
-                raise ShellError('Shell command %s failed with exit status %d'
-                                 % (cmdstr, exitstatus))
+    newenv = {}
+    if "__PRINTENV__" in stdout:
+        newenv = _parse_keyvals(stdout[stdout.index("__PRINTENV__") + 1:])
+        stdout = stdout[:stdout.index("__PRINTENV__")]
 
     # Update os.environ based on changes to environment made by cmdstr
     deltaenv = dict()
     if importenv or getenv:
-        expected_diff_set = set(('PS1', 'PS2', '_', 'SHLVL')) if shell_name == 'bash' else set()
+        expected_diff_set = set(('PS1', 'PS2', '_', 'SHLVL')) if shell in ['bash', "zsh"] else set()
         currenv = dict(os.environ)
-        newenv = _parse_keyvals(shell.sendline_expect("printenv", quiet=True))
         _fix_paths(newenv)
         for key in set(newenv) - expected_diff_set:
             if key not in currenv or currenv[key] != newenv[key]:
@@ -197,18 +166,10 @@ def run_shell(cmdstr, shell='bash', logfile=None, importenv=False, getenv=False,
         if importenv:
             os.environ.update(deltaenv)
 
-    shell.close()
-
-    # expect leaves a stray prompt when logging, so send a linefeed
-    if logfile:
-        logfile.write('\n')
-
-    return outlines, deltaenv
+    return stdout, deltaenv
 
 
-# Some convenience methods
-
-def bash_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None):
+def bash_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None, logger=None, log_level=None):
     """
     Run the command string ``cmdstr`` in a bash shell.  It can have
     multiple lines.  Each line is separately sent to the shell.  The exit status is
@@ -221,35 +182,41 @@ def bash_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None):
     :param importenv: import any environent changes back to python env
     :param getenv: get the environent changes after running ``cmdstr``
     :param env: set environment using ``env`` dict prior to running commands
+    :param logger: log output to the supplied logging.Logger
+    :param log_level: log level for logger
 
     :rtype: (outlines, deltaenv)
     """
-    outlines, newenv = run_shell(cmdstr, shell='bash', logfile=logfile,
-                                 importenv=importenv, getenv=getenv, env=env)
+    outlines, newenv = run_shell(
+        cmdstr,
+        shell='bash',
+        logfile=logfile,
+        importenv=importenv,
+        getenv=getenv,
+         env=env,
+        logger=logger,
+        log_level=log_level
+    )
     return outlines, newenv
 
 
-def bash(cmdstr, logfile=None, importenv=False, env=None):
+def bash(cmdstr, logfile=None, importenv=False, env=None, logger=None, log_level=None):
     """Run the ``cmdstr`` string in a bash shell.  See ``run_shell`` for options.
 
     :returns: bash output
     """
-    outlines, newenv = run_shell(cmdstr, shell='bash', logfile=logfile,
-                                 importenv=importenv, env=env)
-    return outlines
+    return run_shell(cmdstr, shell='bash', logfile=logfile, importenv=importenv, env=env, logger=logger, log_level=log_level)[0]
 
 
-def tcsh(cmdstr, logfile=None, importenv=False, env=None):
+def tcsh(cmdstr, logfile=None, importenv=False, env=None, logger=None, log_level=None):
     """Run the ``cmdstr`` string in a tcsh shell.  See ``run_shell`` for options.
 
     :returns: tcsh output
     """
-    outlines, newenv = run_shell(cmdstr, shell='tcsh', logfile=logfile,
-                                 importenv=importenv, env=env)
-    return outlines
+    return run_shell(cmdstr, shell='tcsh', logfile=logfile, importenv=importenv, env=env, logger=logger, log_level=log_level)[0]
 
 
-def tcsh_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None):
+def tcsh_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None, logger=None, log_level=None):
     """
     Run the command string ``cmdstr`` in a tcsh shell.  It can have
     multiple lines.  Each line is separately sent to the shell.  The exit status is
@@ -262,11 +229,21 @@ def tcsh_shell(cmdstr, logfile=None, importenv=False, getenv=False, env=None):
     :param importenv: import any environent changes back to python env
     :param getenv: get the environent changes after running ``cmdstr``
     :param env: set environment using ``env`` dict prior to running commands
+    :param logger: log output to the supplied logging.Logger
+    :param log_level: log level for logger
 
     :rtype: (outlines, deltaenv)
     """
-    outlines, newenv = run_shell(cmdstr, shell='tcsh', logfile=logfile,
-                                 importenv=importenv, getenv=getenv, env=env)
+    outlines, newenv = run_shell(
+        cmdstr,
+        shell='tcsh',
+        logfile=logfile,
+        importenv=importenv,
+        getenv=getenv,
+         env=env,
+        logger=logger,
+        log_level=log_level
+    )
     return outlines, newenv
 
 
@@ -276,7 +253,7 @@ def getenv(cmdstr, shell='bash', importenv=False, env=None):
     :returns: Dict of environment vars update produced by ``cmdstr``
     """
 
-    outlines, newenv = run_shell(cmdstr, shell=shell, importenv=importenv, env=env, getenv=True)
+    _, newenv = run_shell(cmdstr, shell=shell, importenv=importenv, env=env, getenv=True)
     return newenv
 
 
@@ -286,8 +263,8 @@ def importenv(cmdstr, shell='bash', env=None):
 
     :returns: Dict of environment vars update produced by ``cmdstr``
     """
-    outlines, newenv = run_shell(cmdstr, importenv=True, env=env, shell=shell)
-    return newenv
+    return getenv(cmdstr, importenv=True, env=env, shell=shell)
+
 
 # Null file-like object.  Needed because pyfits spews warnings to stdout
 

--- a/ska_shell/tests/test_shell.py
+++ b/ska_shell/tests/test_shell.py
@@ -1,17 +1,31 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
+
 import pytest
 from six.moves import cStringIO as StringIO
-from ska_shell import (Spawn, RunTimeoutError, bash, tcsh, getenv, importenv,
-                       tcsh_shell, bash_shell, run_shell, ShellError)
 
-HAS_HEAD_CIAO = os.path.exists('/soft/ciao/bin/ciao.sh')
-HAS_HEAD_ASCDS = os.path.exists('/home/ascds/.ascrc')
+from ska_shell import (
+    RunTimeoutError,
+    ShellError,
+    Spawn,
+    bash,
+    bash_shell,
+    getenv,
+    importenv,
+    run_shell,
+    tcsh,
+    tcsh_shell,
+)
 
-outfile = 'ska_shell_test.dat'
+HAS_HEAD_CIAO = os.path.exists("/soft/ciao/bin/ciao.sh")
+HAS_HEAD_ASCDS = os.path.exists("/home/ascds/.ascrc")
+
+outfile = "ska_shell_test.dat"
 
 # Skip the entire test suite on Windows
-pytestmark = pytest.mark.skipif(os.name == 'nt', reason='ska_shell not supported on Windows')
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="ska_shell not supported on Windows"
+)
 
 
 class TestSpawn:
@@ -21,91 +35,93 @@ class TestSpawn:
 
     def test_ok(self):
         spawn = Spawn(stdout=self.f)
-        spawn.run(['echo', 'hello world'])
+        spawn.run(["echo", "hello world"])
         assert spawn.exitstatus == 0
-        assert spawn.outlines == ['hello world\n']
-        assert self.f.getvalue() == 'hello world\n'
+        assert spawn.outlines == ["hello world\n"]
+        assert self.f.getvalue() == "hello world\n"
 
     def test_os_error(self):
         spawn = Spawn(stdout=None)
         with pytest.raises(OSError):
-            spawn.run('bad command')
+            spawn.run("bad command")
         assert spawn.exitstatus is None
 
     def test_timeout_error(self):
         spawn = Spawn(shell=True, timeout=1, stdout=None)
         with pytest.raises(RunTimeoutError):
-            spawn.run('sleep 5')
+            spawn.run("sleep 5")
         assert spawn.exitstatus is None
 
     def test_grab_stderr(self, tmpdir):
         tmp = tmpdir.join("test.out")
-        spawn = Spawn(stderr=tmp.open('w'), stdout=None)
+        spawn = Spawn(stderr=tmp.open("w"), stdout=None)
         spawn.run('perl -e "print STDERR 123456"', shell=True)
 
-        assert tmp.read() == '123456'
+        assert tmp.read() == "123456"
         assert spawn.exitstatus == 0
 
     def test_multi_stdout(self):
         spawn = Spawn(stdout=[self.f, self.g])
         spawn.run('perl -e "print 123456"', shell=True)
-        assert self.f.getvalue() == '123456'
-        assert self.g.getvalue() == '123456'
+        assert self.f.getvalue() == "123456"
+        assert self.g.getvalue() == "123456"
         assert spawn.exitstatus == 0
 
     def test_shell_error(self):
         # With shell=True you don't get an OSError
         spawn = Spawn(shell=True, stdout=None)
-        spawn.run('sadfasdfasdf')
+        spawn.run("sadfasdfasdf")
         assert spawn.exitstatus != 0
         assert spawn.exitstatus is not None
 
 
 class TestBash:
     def test_bash(self):
-        outlines = bash('echo line1; echo line2')
-        assert outlines == ['line1', 'line2']
+        outlines = bash("echo line1; echo line2")
+        assert outlines == ["line1", "line2"]
 
     def test_bash_shell(self):
-        outlines, env = bash_shell('echo line1; echo line2')
-        assert outlines == ['line1', 'line2']
+        outlines, env = bash_shell("echo line1; echo line2")
+        assert outlines == ["line1", "line2"]
         assert env == {}
 
     def test_env(self):
         envs = getenv('export TEST_ENV_VARA="hello"')
-        assert envs['TEST_ENV_VARA'] == 'hello'
+        assert envs["TEST_ENV_VARA"] == "hello"
         assert "TEST_ENV_VARA" not in os.environ
 
-        outlines = bash('echo $TEST_ENV_VARA', env=envs)
-        assert outlines == ['hello']
+        outlines = bash("echo $TEST_ENV_VARA", env=envs)
+        assert outlines == ["hello"]
 
-        envs = getenv("echo", env={"TEST_ENV_VARA": "one"}, shell='bash')
-        assert envs['TEST_ENV_VARA'] == 'one'
+        envs = getenv("echo", env={"TEST_ENV_VARA": "one"}, shell="bash")
+        assert envs["TEST_ENV_VARA"] == "one"
         assert "TEST_ENV_VARA" not in os.environ
 
-        envs = getenv("echo", env={"TEST_ENV_VARA": "two"}, shell='bash', importenv=True)
-        assert envs['TEST_ENV_VARA'] == 'two'
-        assert os.environ["TEST_ENV_VARA"] == 'two'
+        envs = getenv(
+            "echo", env={"TEST_ENV_VARA": "two"}, shell="bash", importenv=True
+        )
+        assert envs["TEST_ENV_VARA"] == "two"
+        assert os.environ["TEST_ENV_VARA"] == "two"
 
-        envs = getenv('export TEST_ENV_VARA="hello"', shell='bash', importenv=True)
-        assert envs['TEST_ENV_VARA'] == 'hello'
-        assert os.environ["TEST_ENV_VARA"] == 'hello'
+        envs = getenv('export TEST_ENV_VARA="hello"', shell="bash", importenv=True)
+        assert envs["TEST_ENV_VARA"] == "hello"
+        assert os.environ["TEST_ENV_VARA"] == "hello"
 
     def test_promptenv(self):
         # Confirm that a messed up PS1 won't be a problem
         # If the user messes with the prompts during use of the shell, all bets are off
         # This test will just hang if the fix isn't implemented (should add pytest-timeout)
-        outlines = bash("echo 'hello'", env={'PS1': "(hello) \\s-\\v\\$"})
-        assert outlines == ['hello']
+        outlines = bash("echo 'hello'", env={"PS1": "(hello) \\s-\\v\\$"})
+        assert outlines == ["hello"]
 
     def test_importenv(self):
-        importenv('export TEST_ENV_VARC="hello"', env={'TEST_ENV_VARB': 'world'})
-        assert os.environ['TEST_ENV_VARC'] == 'hello'
-        assert os.environ['TEST_ENV_VARB'] == 'world'
+        importenv('export TEST_ENV_VARC="hello"', env={"TEST_ENV_VARB": "world"})
+        assert os.environ["TEST_ENV_VARC"] == "hello"
+        assert os.environ["TEST_ENV_VARB"] == "world"
 
     def test_logfile(self):
         logfile = StringIO()
-        cmd = 'echo line1; echo line2'
+        cmd = "echo line1; echo line2"
         bash(cmd, logfile=logfile)
         outlines = logfile.getvalue().splitlines()
 
@@ -114,77 +130,85 @@ class TestBash:
         # the tests reference expected output from the end of the log not the
         # beginning.
         assert outlines[-4].endswith(cmd)
-        assert outlines[-3] == 'line1'
-        assert outlines[-2] == 'line2'
-        assert outlines[-1].startswith('Bash')
+        assert outlines[-3] == "line1"
+        assert outlines[-2] == "line2"
+        assert outlines[-1].startswith("Bash")
 
-    @pytest.mark.skipif('not HAS_HEAD_CIAO', reason='Test requires /soft/ciao/bin/ciao.sh')
+    @pytest.mark.skipif(
+        "not HAS_HEAD_CIAO", reason="Test requires /soft/ciao/bin/ciao.sh"
+    )
     def test_ciao(self):
-        envs = getenv('. /soft/ciao/bin/ciao.sh')
-        test_script = ['printenv {}'.format(name) for name in sorted(envs)]
-        outlines = bash('\n'.join(test_script), env=envs)
+        envs = getenv(". /soft/ciao/bin/ciao.sh")
+        test_script = ["printenv {}".format(name) for name in sorted(envs)]
+        outlines = bash("\n".join(test_script), env=envs)
         assert outlines == [envs[name] for name in sorted(envs)]
 
 
 class TestTcsh:
     def test_tcsh(self):
-        outlines = tcsh('echo line1; echo line2')
-        assert outlines == ['line1', 'line2']
+        outlines = tcsh("echo line1; echo line2")
+        assert outlines == ["line1", "line2"]
 
     def test_tcsh_shell(self):
-        outlines, env = tcsh_shell('echo line1; echo line2')
-        assert outlines == ['line1', 'line2']
+        outlines, env = tcsh_shell("echo line1; echo line2")
+        assert outlines == ["line1", "line2"]
         assert env == {}
 
     def test_env(self):
-        envs = getenv('setenv TEST_ENV_VAR2 "hello"', shell='tcsh')
-        assert envs['TEST_ENV_VAR2'] == 'hello'
+        envs = getenv('setenv TEST_ENV_VAR2 "hello"', shell="tcsh")
+        assert envs["TEST_ENV_VAR2"] == "hello"
         assert "TEST_ENV_VAR2" not in os.environ
 
-        outlines = tcsh('echo $TEST_ENV_VAR2', env=envs)
-        assert outlines == ['hello']
+        outlines = tcsh("echo $TEST_ENV_VAR2", env=envs)
+        assert outlines == ["hello"]
 
-        envs = getenv("echo", env={"TEST_ENV_VAR2": "one"}, shell='tcsh')
-        assert envs['TEST_ENV_VAR2'] == 'one'
+        envs = getenv("echo", env={"TEST_ENV_VAR2": "one"}, shell="tcsh")
+        assert envs["TEST_ENV_VAR2"] == "one"
         assert "TEST_ENV_VAR2" not in os.environ
 
-        envs = getenv("echo", env={"TEST_ENV_VAR2": "two"}, shell='tcsh', importenv=True)
-        assert envs['TEST_ENV_VAR2'] == 'two'
-        assert os.environ["TEST_ENV_VAR2"] == 'two'
+        envs = getenv(
+            "echo", env={"TEST_ENV_VAR2": "two"}, shell="tcsh", importenv=True
+        )
+        assert envs["TEST_ENV_VAR2"] == "two"
+        assert os.environ["TEST_ENV_VAR2"] == "two"
 
-        envs = getenv('setenv TEST_ENV_VAR2 "hello"', shell='tcsh', importenv=True)
-        assert envs['TEST_ENV_VAR2'] == 'hello'
-        assert os.environ["TEST_ENV_VAR2"] == 'hello'
+        envs = getenv('setenv TEST_ENV_VAR2 "hello"', shell="tcsh", importenv=True)
+        assert envs["TEST_ENV_VAR2"] == "hello"
+        assert os.environ["TEST_ENV_VAR2"] == "hello"
 
     def test_importenv(self):
-        importenv('setenv TEST_ENV_VAR3 "hello"', env={'TEST_ENV_VAR4': 'world'}, shell='tcsh')
-        assert os.environ['TEST_ENV_VAR3'] == 'hello'
-        assert os.environ['TEST_ENV_VAR4'] == 'world'
+        importenv(
+            'setenv TEST_ENV_VAR3 "hello"', env={"TEST_ENV_VAR4": "world"}, shell="tcsh"
+        )
+        assert os.environ["TEST_ENV_VAR3"] == "hello"
+        assert os.environ["TEST_ENV_VAR4"] == "world"
 
     def test_logfile(self, tmpdir):
         logfile = StringIO()
-        cmd = 'echo line1; echo line2'
+        cmd = "echo line1; echo line2"
         tcsh(cmd, logfile=logfile)
         out = logfile.getvalue()
         outlines = out.strip().splitlines()
         assert outlines[0].endswith(cmd)
         # assert outlines[1] == ''
-        assert outlines[1] == 'line1'
-        assert outlines[2] == 'line2'
-        assert outlines[3].startswith('Tcsh')
+        assert outlines[1] == "line1"
+        assert outlines[2] == "line2"
+        assert outlines[3].startswith("Tcsh")
 
-    @pytest.mark.skipif('not HAS_HEAD_ASCDS', reason='Test requires /home/ascds/.ascrc')
+    @pytest.mark.skipif("not HAS_HEAD_ASCDS", reason="Test requires /home/ascds/.ascrc")
     def test_ascds(self):
-        envs = getenv('source /home/ascds/.ascrc -r release', shell='tcsh')
-        test_script = ['printenv {}'.format(name) for name in sorted(envs)]
-        outlines = tcsh('\n'.join(test_script), env=envs)
+        envs = getenv("source /home/ascds/.ascrc -r release", shell="tcsh")
+        test_script = ["printenv {}".format(name) for name in sorted(envs)]
+        outlines = tcsh("\n".join(test_script), env=envs)
         assert outlines == [envs[name] for name in sorted(envs)]
 
-    @pytest.mark.skipif('not HAS_HEAD_CIAO', reason='Test requires /soft/ciao/bin/ciao.sh')
+    @pytest.mark.skipif(
+        "not HAS_HEAD_CIAO", reason="Test requires /soft/ciao/bin/ciao.sh"
+    )
     def test_ciao(self):
-        envs = getenv('source /soft/ciao/bin/ciao.csh', shell='tcsh')
-        test_script = ['printenv {}'.format(name) for name in sorted(envs)]
-        outlines = tcsh('\n'.join(test_script), env=envs)
+        envs = getenv("source /soft/ciao/bin/ciao.csh", shell="tcsh")
+        test_script = ["printenv {}".format(name) for name in sorted(envs)]
+        outlines = tcsh("\n".join(test_script), env=envs)
         assert outlines == [envs[name] for name in sorted(envs)]
 
 
@@ -197,6 +221,7 @@ def test_error(shell):
     echo three
     """
     with pytest.raises(
-        ShellError, match="idonotexist.*[Cc]ommand not found|[Cc]ommand not found.*idonotexist"
+        ShellError,
+        match="idonotexist.*[Cc]ommand not found|[Cc]ommand not found.*idonotexist",
     ):
         run_shell(cmds, shell=shell)

--- a/ska_shell/tests/test_shell.py
+++ b/ska_shell/tests/test_shell.py
@@ -74,8 +74,22 @@ class TestBash:
     def test_env(self):
         envs = getenv('export TEST_ENV_VARA="hello"')
         assert envs['TEST_ENV_VARA'] == 'hello'
+        assert "TEST_ENV_VARA" not in os.environ
+
         outlines = bash('echo $TEST_ENV_VARA', env=envs)
         assert outlines == ['hello']
+
+        envs = getenv("echo", env={"TEST_ENV_VARA": "one"}, shell='bash')
+        assert envs['TEST_ENV_VARA'] == 'one'
+        assert "TEST_ENV_VARA" not in os.environ
+
+        envs = getenv("echo", env={"TEST_ENV_VARA": "two"}, shell='bash', importenv=True)
+        assert envs['TEST_ENV_VARA'] == 'two'
+        assert os.environ["TEST_ENV_VARA"] == 'two'
+
+        envs = getenv('export TEST_ENV_VARA="hello"', shell='bash', importenv=True)
+        assert envs['TEST_ENV_VARA'] == 'hello'
+        assert os.environ["TEST_ENV_VARA"] == 'hello'
 
     def test_promptenv(self):
         # Confirm that a messed up PS1 won't be a problem
@@ -125,8 +139,22 @@ class TestTcsh:
     def test_env(self):
         envs = getenv('setenv TEST_ENV_VAR2 "hello"', shell='tcsh')
         assert envs['TEST_ENV_VAR2'] == 'hello'
+        assert "TEST_ENV_VAR2" not in os.environ
+
         outlines = tcsh('echo $TEST_ENV_VAR2', env=envs)
         assert outlines == ['hello']
+
+        envs = getenv("echo", env={"TEST_ENV_VAR2": "one"}, shell='tcsh')
+        assert envs['TEST_ENV_VAR2'] == 'one'
+        assert "TEST_ENV_VAR2" not in os.environ
+
+        envs = getenv("echo", env={"TEST_ENV_VAR2": "two"}, shell='tcsh', importenv=True)
+        assert envs['TEST_ENV_VAR2'] == 'two'
+        assert os.environ["TEST_ENV_VAR2"] == 'two'
+
+        envs = getenv('setenv TEST_ENV_VAR2 "hello"', shell='tcsh', importenv=True)
+        assert envs['TEST_ENV_VAR2'] == 'hello'
+        assert os.environ["TEST_ENV_VAR2"] == 'hello'
 
     def test_importenv(self):
         importenv('setenv TEST_ENV_VAR3 "hello"', env={'TEST_ENV_VAR4': 'world'}, shell='tcsh')
@@ -140,10 +168,10 @@ class TestTcsh:
         out = logfile.getvalue()
         outlines = out.strip().splitlines()
         assert outlines[0].endswith(cmd)
-        assert outlines[1] == ''
-        assert outlines[2] == 'line1'
-        assert outlines[3] == 'line2'
-        assert outlines[4].startswith('Tcsh')
+        # assert outlines[1] == ''
+        assert outlines[1] == 'line1'
+        assert outlines[2] == 'line2'
+        assert outlines[3].startswith('Tcsh')
 
     @pytest.mark.skipif('not HAS_HEAD_ASCDS', reason='Test requires /home/ascds/.ascrc')
     def test_ascds(self):

--- a/ska_shell/tests/test_shell.py
+++ b/ska_shell/tests/test_shell.py
@@ -5,6 +5,7 @@ import pytest
 from six.moves import cStringIO as StringIO
 
 from ska_shell import (
+    NonZeroReturnCode,
     RunTimeoutError,
     ShellError,
     Spawn,
@@ -143,6 +144,14 @@ class TestBash:
         outlines = bash("\n".join(test_script), env=envs)
         assert outlines == [envs[name] for name in sorted(envs)]
 
+    def test_check(self):
+        out = bash("lsd; echo DONE", check=False)
+        assert len(out) == 2
+        assert out[-1] == "DONE"
+
+        with pytest.raises(NonZeroReturnCode):
+            out = bash("lsd; echo DONE", check=True)
+
 
 class TestTcsh:
     def test_tcsh(self):
@@ -210,6 +219,14 @@ class TestTcsh:
         test_script = ["printenv {}".format(name) for name in sorted(envs)]
         outlines = tcsh("\n".join(test_script), env=envs)
         assert outlines == [envs[name] for name in sorted(envs)]
+
+    def test_check(self):
+        out = bash("lsd; echo DONE", check=False)
+        assert len(out) == 2
+        assert out[-1] == "DONE"
+
+        with pytest.raises(NonZeroReturnCode):
+            out = bash("lsd; echo DONE", check=True)
 
 
 @pytest.mark.parametrize("shell", ["bash", "tcsh", "zsh"])

--- a/ska_shell/tests/test_shell.py
+++ b/ska_shell/tests/test_shell.py
@@ -6,6 +6,7 @@ from ska_shell import (Spawn, RunTimeoutError, bash, tcsh, getenv, importenv,
                        tcsh_shell, bash_shell)
 
 HAS_HEAD_CIAO = os.path.exists('/soft/ciao/bin/ciao.sh')
+HAS_HEAD_ASCDS = os.path.exists('/home/ascds/.ascrc')
 
 outfile = 'ska_shell_test.dat'
 
@@ -144,12 +145,14 @@ class TestTcsh:
         assert outlines[3] == 'line2'
         assert outlines[4].startswith('Tcsh')
 
+    @pytest.mark.skipif('not HAS_HEAD_ASCDS', reason='Test requires /home/ascds/.ascrc')
     def test_ascds(self):
         envs = getenv('source /home/ascds/.ascrc -r release', shell='tcsh')
         test_script = ['printenv {}'.format(name) for name in sorted(envs)]
         outlines = tcsh('\n'.join(test_script), env=envs)
         assert outlines == [envs[name] for name in sorted(envs)]
 
+    @pytest.mark.skipif('not HAS_HEAD_CIAO', reason='Test requires /soft/ciao/bin/ciao.sh')
     def test_ciao(self):
         envs = getenv('source /soft/ciao/bin/ciao.csh', shell='tcsh')
         test_script = ['printenv {}'.format(name) for name in sorted(envs)]

--- a/ska_shell/tests/test_shell.py
+++ b/ska_shell/tests/test_shell.py
@@ -230,7 +230,7 @@ class TestTcsh:
 
 
 @pytest.mark.parametrize("shell", ["bash", "tcsh", "zsh"])
-def test_error(shell):
+def test_err(shell):
     cmds = """
     echo one
     idonotexist

--- a/ska_shell/tests/test_shell.py
+++ b/ska_shell/tests/test_shell.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from six.moves import cStringIO as StringIO
 from ska_shell import (Spawn, RunTimeoutError, bash, tcsh, getenv, importenv,
-                       tcsh_shell, bash_shell)
+                       tcsh_shell, bash_shell, run_shell, ShellError)
 
 HAS_HEAD_CIAO = os.path.exists('/soft/ciao/bin/ciao.sh')
 HAS_HEAD_ASCDS = os.path.exists('/home/ascds/.ascrc')
@@ -186,3 +186,17 @@ class TestTcsh:
         test_script = ['printenv {}'.format(name) for name in sorted(envs)]
         outlines = tcsh('\n'.join(test_script), env=envs)
         assert outlines == [envs[name] for name in sorted(envs)]
+
+
+@pytest.mark.parametrize("shell", ["bash", "tcsh", "zsh"])
+def test_error(shell):
+    cmds = """
+    echo one
+    idonotexist
+    echo two
+    echo three
+    """
+    with pytest.raises(
+        ShellError, match="idonotexist.*[Cc]ommand not found|[Cc]ommand not found.*idonotexist"
+    ):
+        run_shell(cmds, shell=shell)


### PR DESCRIPTION
## Description

This PR removes uses of pexpect in ska_shell.

It also adds a `check` argument to several functions. `check=True` causes an exception if any command returns a non-zero code. `check=False` runs all commands even if one fails and no exception is raised. `getenv` does not have the `check` argument. The current behavior in master varies, but I have seen cases where it does not raise an exception (even though the docstring says it should).

It also does some small unrelated changes:
- fix the docstring of bash_shell and tcsh_shell
- ruff. Sorry this might make it hard to evaluate. I can back that commit out if you prefer.
- renamed a function called `test_error` which for some reason triggered a failure when running testr. I don't know why this did not fail before and failed now, but it does not hurt to just change the name.

## Notes

A small complicating issue was that the tcsh call was always loading `.cshrc`, and that was overwriting the PATH given as input. To sidestep this, the call to tcsh is wrapped in a call to bash, and then bash calls tcsh with the `-f` option.

This PR was motivated by warnings appearing in tests that were caused by pexpect ([mica](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.2rc1-HEAD/mica/post_check_logs.log) and [agasc](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.2rc1-HEAD/agasc/post_check_logs.log)).

An alternative is #30, where I only removed uses of pexpect in the `getenv` function.

## Interface impacts

- added `check` argument to `run_shell`, `bash`, `bash_shell`, `tcsh`, `tcsh_shell`
- added a feature to pass a logger to `run_shell`. The logger is called continuously, so you get a log as the program progresses. This is useful for long-running processes. I used this in runasp.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
- [x] Linux

```
(ska3-flight-2025.1rc1) jgonzale ska_shell $ pytest ska_shell
========================================================= test session starts =========================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: anyio-4.7.0, dash-2.18.2, timeout-2.3.1
collected 25 items                                                                                                                    

ska_shell/tests/test_shell.py .........................                                                                         [100%]

========================================================= 25 passed in 3.35s ==========================================================
(ska3-flight-2025.1rc1) jgonzale ska_shell $ git rev-parse HEAD
3215cf2bcf19004be0033e5b7477eeba614c8da4
```

Independent check of unit tests by Jean
- [x] Linux
```
ska3-jeanconn-fido> git rev-parse HEAD
76dd49b26da847b59e5efe17daaf42e010fef2fb
ska3-jeanconn-fido> pytest
============================= test session starts ==============================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 25 items                                                                                                                 

ska_shell/tests/test_shell.py .........................                                                                      [100%]

======================================================== 25 passed in 3.93s
```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

```python
import logging
from ska_shell import run_shell, getenv

logging.basicConfig(level="INFO")
logger = logging.getLogger("name")

cmds = """python -c 'import time; time.sleep(2); print("here")'
python -c 'import time; time.sleep(2); print("here")'
python -c 'import time; time.sleep(2); print("here")'
"""

run_shell(cmds, logger=logger)
```

After running the tests linked in the description, I installed this branch into that environment and ran 
```
run_testr --include mica --include agasc
```
and the warning in agasc went away (not the one in kadi).

JC ran the aimpoint code that calls dmcoords and it did not fail
```
In [1]: run aimpoint_mon/update_observed_aimpoints.py --data-root test
2025-03-05 08:28:16,503 Getting 30808 ACIS-S from archive
2025-03-05 08:28:19,375 Obsid=30808 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-2.3 dy=-0.9 dr=2.4
2025-03-05 08:28:19,383 Getting 30805 ACIS-I from archive
2025-03-05 08:28:21,602 Obsid=30805 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-2.4 dy=3.4 dr=4.1
2025-03-05 08:28:21,609 Getting 30374 ACIS-S from archive
2025-03-05 08:28:23,809 Obsid=30374 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-4.3 dy=-1.2 dr=4.4
2025-03-05 08:28:23,817 Getting 28612 ACIS-I from archive
2025-03-05 08:28:25,978 Obsid=28612 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-1.8 dy=3.3 dr=3.8
2025-03-05 08:28:25,985 Getting 30809 ACIS-S from archive
2025-03-05 08:28:28,226 Obsid=30809 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-3.0 dy=-2.1 dr=3.7
2025-03-05 08:28:28,233 Getting 28630 ACIS-I from archive
2025-03-05 08:28:30,398 Obsid=28630 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-1.7 dy=2.8 dr=3.3
2025-03-05 08:28:30,406 Getting 30376 ACIS-S from archive
2025-03-05 08:28:32,612 Obsid=30376 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-2.7 dy=-1.4 dr=3.1
2025-03-05 08:28:32,620 Getting 30801 ACIS-I from archive
2025-03-05 08:28:34,809 Obsid=30801 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-1.0 dy=2.3 dr=2.5
2025-03-05 08:28:34,818 Getting 28532 ACIS-S from archive
2025-03-05 08:28:37,124 Obsid=28532 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-2.6 dy=-1.7 dr=3.1
2025-03-05 08:28:37,132 Getting 30803 ACIS-I from archive
2025-03-05 08:28:39,334 Obsid=30803 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-1.9 dy=2.4 dr=3.1
2025-03-05 08:28:39,342 Getting 28099 ACIS-S from archive
2025-03-05 08:28:41,852 Obsid=28099 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-3.6 dy=-2.6 dr=4.5
2025-03-05 08:28:41,859 Getting 30799 ACIS-S from archive
2025-03-05 08:28:44,386 Obsid=30799 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-1.7 dy=-1.9 dr=2.6
2025-03-05 08:28:44,395 Getting 30804 ACIS-I from archive
2025-03-05 08:28:46,599 Obsid=30804 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-2.4 dy=3.8 dr=4.5
2025-03-05 08:28:46,606 Getting 30810 ACIS-S from archive
2025-03-05 08:28:48,851 Obsid=30810 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-4.6 dy=-1.0 dr=4.7
2025-03-05 08:28:48,859 Getting 30802 ACIS-I from archive
2025-03-05 08:28:51,033 Obsid=30802 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-3.1 dy=3.9 dr=5.0
2025-03-05 08:28:51,040 Getting 29771 ACIS-S from archive
2025-03-05 08:28:53,194 Obsid=29771 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-7.5 dy=-9.3 dr=11.9
2025-03-05 08:28:53,203 Getting 28582 ACIS-S from archive
2025-03-05 08:28:55,697 Obsid=28582 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-3.7 dy=-3.1 dr=4.8
2025-03-05 08:28:55,707 Getting 29831 ACIS-S from archive
2025-03-05 08:28:58,010 Obsid=29831 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-2.2 dy=-2.7 dr=3.5
2025-03-05 08:28:58,018 Getting 30800 ACIS-S from archive
2025-03-05 08:29:00,279 Obsid=30800 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-1.6 dy=-2.7 dr=3.1
2025-03-05 08:29:00,286 Getting 29740 ACIS-I from archive
2025-03-05 08:29:02,450 Obsid=29740 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-2.2 dy=1.5 dr=2.7
2025-03-05 08:29:02,458 Getting 30551 HRC-S from archive
2025-03-05 08:29:06,687 Obsid=30551 detector=HRC-S  chipx=2195.0 chipy=8915.0 dx=-1.3 dy=4.8 dr=5.0
2025-03-05 08:29:06,695 Getting 28560 ACIS-S from archive
2025-03-05 08:29:08,940 Obsid=28560 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-4.8 dy=-2.9 dr=5.6
2025-03-05 08:29:08,948 Getting 28132 ACIS-S from archive
2025-03-05 08:29:11,625 Obsid=28132 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-4.1 dy=-2.1 dr=4.6
2025-03-05 08:29:11,633 Getting 30587 ACIS-I from archive
2025-03-05 08:29:14,375 Obsid=30587 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-0.7 dy=2.1 dr=2.2
2025-03-05 08:29:14,382 Getting 30239 ACIS-I from archive
2025-03-05 08:29:16,842 Obsid=30239 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-2.0 dy=2.1 dr=2.9
2025-03-05 08:29:16,852 Getting 30823 ACIS-I from archive
2025-03-05 08:29:19,115 Obsid=30823 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-1.3 dy=2.3 dr=2.7
2025-03-05 08:29:19,123 Getting 30820 ACIS-I from archive
2025-03-05 08:29:21,669 Obsid=30820 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-1.8 dy=2.8 dr=3.3
2025-03-05 08:29:21,676 Getting 30278 ACIS-I from archive
2025-03-05 08:29:25,402 Obsid=30278 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-2.4 dy=2.7 dr=3.6
2025-03-05 08:29:25,409 Getting 30553 HRC-S from archive
2025-03-05 08:29:29,481 Obsid=30553 detector=HRC-S  chipx=2195.0 chipy=8915.0 dx=-0.2 dy=1.3 dr=1.3
2025-03-05 08:29:29,488 Getting 26975 ACIS-I from archive
2025-03-05 08:29:31,784 Obsid=26975 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-2.0 dy=-0.3 dr=2.0
2025-03-05 08:29:31,791 Getting 30821 ACIS-I from archive
2025-03-05 08:29:33,962 Obsid=30821 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-1.8 dy=-0.9 dr=2.0
2025-03-05 08:29:33,970 Getting 30032 ACIS-S from archive
2025-03-05 08:29:36,272 Obsid=30032 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-0.6 dy=-1.3 dr=1.4
2025-03-05 08:29:36,280 Getting 30555 HRC-S from archive
2025-03-05 08:29:40,716 Obsid=30555 detector=HRC-S  chipx=2195.0 chipy=8915.0 dx=-0.4 dy=0.7 dr=0.8
2025-03-05 08:29:40,724 Getting 30284 ACIS-I from archive
2025-03-05 08:29:43,874 Obsid=30284 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-0.7 dy=0.6 dr=0.9
2025-03-05 08:29:43,881 Getting 29646 ACIS-S from archive
2025-03-05 08:29:46,133 Obsid=29646 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-1.6 dy=-1.0 dr=1.9
2025-03-05 08:29:46,141 Getting 29965 ACIS-S from archive
2025-03-05 08:29:48,253 Obsid=29965 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-3.1 dy=0.1 dr=3.1
2025-03-05 08:29:48,260 Getting 29884 ACIS-S from archive
2025-03-05 08:29:51,001 Obsid=29884 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-1.2 dy=-1.3 dr=1.8
2025-03-05 08:29:51,009 Getting 30824 ACIS-I from archive
2025-03-05 08:29:53,167 Obsid=30824 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-2.3 dy=1.5 dr=2.8
2025-03-05 08:29:53,175 Getting 30556 HRC-S from archive
2025-03-05 08:29:58,002 Obsid=30556 detector=HRC-S  chipx=2195.0 chipy=8915.0 dx=-0.3 dy=2.7 dr=2.7
2025-03-05 08:29:58,009 Getting 30813 ACIS-S from archive
2025-03-05 08:30:00,282 Obsid=30813 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-1.6 dy=-2.8 dr=3.2
2025-03-05 08:30:00,292 Getting 29838 ACIS-I from archive
2025-03-05 08:30:02,699 Obsid=29838 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-2.1 dy=2.4 dr=3.2
2025-03-05 08:30:02,707 Getting 30814 ACIS-S from archive
2025-03-05 08:30:05,098 Obsid=30814 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-2.8 dy=-1.4 dr=3.2
2025-03-05 08:30:05,104 Getting 30285 ACIS-I from archive
2025-03-05 08:30:08,448 Obsid=30285 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-2.6 dy=3.3 dr=4.2
2025-03-05 08:30:08,456 Getting 30822 HRC-S from archive
2025-03-05 08:30:12,110 Obsid=30822 detector=HRC-S  chipx=2195.0 chipy=8915.0 dx=-0.7 dy=2.7 dr=2.8
2025-03-05 08:30:12,118 Getting 29647 ACIS-S from archive
2025-03-05 08:30:14,416 Obsid=29647 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-1.3 dy=-0.8 dr=1.5
2025-03-05 08:30:14,424 Getting 30819 ACIS-S from archive
2025-03-05 08:30:16,837 Obsid=30819 detector=ACIS-S chipx=193.7 chipy=520.0 dx=0.0 dy=-1.1 dr=1.1
2025-03-05 08:30:16,845 Getting 29704 ACIS-I from archive
2025-03-05 08:30:19,139 Obsid=29704 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-4.9 dy=0.5 dr=4.9
2025-03-05 08:30:19,155 Getting 30812 ACIS-S from archive
2025-03-05 08:30:21,668 Obsid=30812 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-2.4 dy=-1.6 dr=2.9
2025-03-05 08:30:21,676 Getting 29705 ACIS-I from archive
2025-03-05 08:30:23,954 Obsid=29705 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-0.0 dy=3.3 dr=3.3
2025-03-05 08:30:23,961 Getting 29706 ACIS-I from archive
2025-03-05 08:30:26,041 Obsid=29706 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-2.9 dy=2.3 dr=3.7
2025-03-05 08:30:26,048 Getting 30815 ACIS-S from archive
2025-03-05 08:30:28,282 Obsid=30815 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-2.5 dy=-1.9 dr=3.1
2025-03-05 08:30:28,289 Getting 30817 ACIS-S from archive
2025-03-05 08:30:30,529 Obsid=30817 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-1.5 dy=-2.6 dr=3.0
2025-03-05 08:30:30,537 Getting 29707 ACIS-I from archive
2025-03-05 08:30:32,638 Obsid=29707 detector=ACIS-I chipx=953.7 chipy=958.7 dx=0.4 dy=2.0 dr=2.0
2025-03-05 08:30:32,645 Getting 30818 ACIS-S from archive
2025-03-05 08:30:34,891 Obsid=30818 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-1.5 dy=-0.7 dr=1.7
2025-03-05 08:30:34,898 Getting 29708 ACIS-I from archive
2025-03-05 08:30:37,032 Obsid=29708 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-3.3 dy=0.7 dr=3.3
2025-03-05 08:30:37,039 Getting 30816 ACIS-S from archive
2025-03-05 08:30:39,375 Obsid=30816 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-2.2 dy=-1.3 dr=2.6
2025-03-05 08:30:39,387 Getting 28342 HRC-I from archive
2025-03-05 08:30:42,752 Obsid=28342 detector=HRC-I  chipx=7590.0 chipy=7745.0 dx=1.7 dy=3.4 dr=3.8
2025-03-05 08:30:42,760 Getting 29709 ACIS-I from archive
2025-03-05 08:30:44,890 Obsid=29709 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-5.0 dy=2.4 dr=5.5
2025-03-05 08:30:44,898 Getting 28562 ACIS-S from archive
2025-03-05 08:30:47,470 Obsid=28562 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-2.1 dy=-1.1 dr=2.4
2025-03-05 08:30:47,480 Getting 28152 ACIS-S from archive
2025-03-05 08:30:49,639 Obsid=28152 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-1.9 dy=-1.2 dr=2.2
2025-03-05 08:30:49,646 Getting 30830 HRC-I from archive
2025-03-05 08:30:52,745 Obsid=30830 detector=HRC-I  chipx=7590.0 chipy=7745.0 dx=1.1 dy=4.1 dr=4.2
2025-03-05 08:30:52,752 Getting 29710 ACIS-I from archive
2025-03-05 08:30:54,841 Obsid=29710 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-1.9 dy=1.5 dr=2.5
2025-03-05 08:30:54,848 Getting 30831 ACIS-S from archive
2025-03-05 08:30:57,067 Obsid=30831 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-2.4 dy=-1.4 dr=2.8
2025-03-05 08:30:57,076 Getting 30827 ACIS-S from archive
2025-03-05 08:30:59,610 Obsid=30827 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-1.9 dy=-2.1 dr=2.8
2025-03-05 08:30:59,622 Getting 29711 ACIS-I from archive
2025-03-05 08:31:02,172 Obsid=29711 detector=ACIS-I chipx=953.7 chipy=958.7 dx=-3.5 dy=2.1 dr=4.1
2025-03-05 08:31:02,180 Getting 30832 ACIS-S from archive
2025-03-05 08:31:04,695 Obsid=30832 detector=ACIS-S chipx=193.7 chipy=520.0 dx=-2.8 dy=-1.9 dr=3.4
2025-03-05 08:31:04,698 Writing test/observed_aimpoints.dat
2025-03-05 08:31:06,877 Writing plot files test/observed_aimpoints.png
2025-03-05 08:31:11,161 Writing plot files test/observed_aimpoints.pdf
```